### PR TITLE
Remove GitHub Pages deployment instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,3 @@ to run locally run this in the web-diii root directory then browse to localhost:
 ```bash
 python3 -m http.server 8000
 ```
-
-## GitHub Pages deployment
-
-This repo includes GitHub Actions workflows for Pages:
-
-- Pushes to `main` deploy to production Pages.
-- PRs targeting `main` deploy to preview URLs.
-
-Notes:
-
-- PR preview deployments run only for PRs from branches in this repository (not forks).
-- The preview URL is shown in the PR checks/deployment details.


### PR DESCRIPTION
Removed GitHub Pages deployment section from README.